### PR TITLE
Bump omniauth-ucam-raven to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -136,4 +136,4 @@ gem "recaptcha"
 
 gem 'i18n-language-mapping', '~> 0.1.1'
 
-gem 'omniauth-ucam-raven'
+gem 'omniauth-ucam-raven', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     omniauth-twitter (1.4.0)
       omniauth-oauth (~> 1.1)
       rack
-    omniauth-ucam-raven (1.0.1)
+    omniauth-ucam-raven (2.0.0)
       omniauth (~> 1.0)
     pagy (3.8.1)
     parallel (1.19.1)
@@ -364,7 +364,7 @@ DEPENDENCIES
   omniauth-bn-office365 (~> 0.1.1)
   omniauth-google-oauth2
   omniauth-twitter
-  omniauth-ucam-raven
+  omniauth-ucam-raven (~> 2.0)
   pagy
   pg (~> 0.18)
   puma (~> 3.12)

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -66,9 +66,9 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     end
 
     if Rails.configuration.omniauth_ucamraven
+      key_data = [[ENV['KEY_ID'], ENV['KEY_PATH']]]
       Rails.application.config.providers << :ucamraven
-      provider :ucamraven, ENV['KEY_ID'].to_i, ENV['KEY_PATH'], :desc => ENV['RAVEN_DESC'],
-        setup: SETUP_PROC
+      provider :ucamraven, key_data, desc: ENV['RAVEN_DESC'], setup: SETUP_PROC
     end
 
   end


### PR DESCRIPTION
omniauth-ucam-raven v2 brings some mild security improvements as well as support for Goose, should you want that in future. See the [CHANGELOG](https://github.com/CHTJonas/omniauth-ucam-raven/blob/master/CHANGELOG.md#200---2020-05-27) for full details.