### PR TITLE
Gracefully handle a cancelled Raven login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -118,8 +118,11 @@ class SessionsController < ApplicationController
 
   # POST /auth/failure
   def omniauth_fail
-    if params[:message].nil?
+    case params[:message]
+    when nil
       redirect_to root_path, alert: I18n.t("omniauth_error")
+    when 'authentication_cancelled_by_user'
+      root_path, info: 'Raven login declined gracefully. Returning you to the home page.'
     else
       redirect_to root_path, alert: I18n.t("omniauth_specific_error", error: params["message"])
     end


### PR DESCRIPTION
Use a more graceful Bootstrap style and alert message when handling aborted Raven logins. This is currently setup using a static string - would you like me to drop it into `config/locales/en.yml` instead?