### PR TITLE
Don't show room title in admin room list (attempt 2)

### DIFF
--- a/app/views/admins/components/_rooms.html.erb
+++ b/app/views/admins/components/_rooms.html.erb
@@ -19,14 +19,6 @@
       <table id="rooms-table" class="table table-hover table-outline table-vcenter card-table">
         <thead>
           <tr>
-            <th data-header="name" data-order="<%= @order_column == "name" ? @order_direction : "none" %>">
-              <%= t("administrator.users.table.name") %>
-              <% if @order_column == "name" && @order_direction == "desc" %>
-                ↓
-              <% elsif @order_column == "name" && @order_direction == "asc" %>
-                ↑
-              <% end %>
-            </th>
             <th data-header="users.name" data-order="<%= @order_column == "users.name" ? @order_direction : "none" %>">
               <%= t("room.owner") %>
               <% if @order_column == "users.name" && @order_direction == "desc" %>

--- a/app/views/admins/components/_server_room_row.html.erb
+++ b/app/views/admins/components/_server_room_row.html.erb
@@ -14,25 +14,11 @@
 %>
 
 <tr class="room-block" data-path="<%= update_settings_path(room) %>" data-room-settings=<%= room.room_settings %> data-room-access-code="<%= room.access_code %>">
-  <td>
-    <div id="room-title" class="edit_hover_class">
-      <span class="room-name-text" title="[redacted]">
-        <%= "[redacted]" %>
-      </span>
-    </div>
-    <div class="small text-muted">
-      <% running = room_is_running(room.bbb_id) %>
-      <% if running %>
-         <%= t("administrator.rooms.table.started", session: friendly_time(room.last_session)) %>
-      <% elsif room.last_session.present? %>
-        <%= t("administrator.rooms.table.ended", session: friendly_time(room.last_session)) %>
-      <% else %>
-        <%= [t("administrator.users.table.created"), ": ", friendly_time(room.created_at)].join %>
-      <% end %>
-    </div>
-  </td>
   <td class="text-left">
     <%= room.owner.name %>
+    <% if room.id == room.owner.room_id %>
+      <i class="fas fa-home pr-1"></i>
+    <% end %>
   </td>
   <td class="text-left">
     <%= room.uid %>
@@ -41,11 +27,21 @@
     <%= @participants_count[room.bbb_id].presence || "-" %>
   </td>
   <td class="text-left">
+    <% running = room_is_running(room.bbb_id) %>
     <% if running %>
       <%= t("administrator.rooms.table.running") %>
     <% else %>
       <%= t("administrator.rooms.table.not_running") %>
     <% end %>
+    <div class="small text-muted">
+      <% if running %>
+         <%= t("administrator.rooms.table.started", session: friendly_time(room.last_session)) %>
+      <% elsif room.last_session.present? %>
+        <%= t("administrator.rooms.table.ended", session: friendly_time(room.last_session)) %>
+      <% else %>
+        <%= [t("administrator.users.table.created"), ": ", friendly_time(room.created_at)].join %>
+      <% end %>
+    </div>
   </td>
   <td class="text-center">
     <div class="item-action dropdown">


### PR DESCRIPTION
https://github.com/SRCF/greenlight/pull/3 but this time I set `running` _before_ it's used.